### PR TITLE
优化从task_map过滤线程部分的可读性，以及调参

### DIFF
--- a/src/cpu_common/process_monitor.rs
+++ b/src/cpu_common/process_monitor.rs
@@ -88,11 +88,11 @@ fn monitor_thread(receiver: &Receiver<Option<pid_t>>, max_usage_tid: &Sender<(pi
         }
 
         if let Some(pid) = current_pid {
-            if last_full_update.elapsed() > Duration::from_millis(1500) {
+            if last_full_update.elapsed() > Duration::from_millis(2000) {
                 let Ok(threads) = get_target_tids(rx) else {
                     #[cfg(debug_assertions)]
                     debug!("错误获取，休眠后跳过");
-                    thread::sleep(Duration::from_millis(900));
+                    thread::sleep(Duration::from_millis(300));
                     continue;
                 };
 
@@ -143,7 +143,7 @@ fn monitor_thread(receiver: &Receiver<Option<pid_t>>, max_usage_tid: &Sender<(pi
                 max_usage_tid.send((top_two[0].0, top_two[1].0)).unwrap();
             }
         }
-        thread::sleep(Duration::from_millis(900));
+        thread::sleep(Duration::from_millis(650));
     }
 }
 

--- a/src/policy/usage/mod.rs
+++ b/src/policy/usage/mod.rs
@@ -18,14 +18,10 @@ pub static UNNAME_TIDS: Lazy<ChannelType> = Lazy::new(|| bounded(0));
 fn get_thread_tids(task_map: &HashMap<pid_t, CompactString>, prefix: &str) -> Vec<pid_t> {
     #[cfg(debug_assertions)]
     debug!("原始的task_map:{task_map:?}");
+
     task_map
         .iter()
-        .filter_map(|(&tid, name)| {
-            if name.starts_with(prefix) {
-                Some(tid)
-            } else {
-                None
-            }
-        })
+        .filter(|(_, name)| name.starts_with(prefix))
+        .map(|(&tid, _)| tid)
         .collect()
 }

--- a/src/policy/usage/usage_top2/policy_unname2.rs
+++ b/src/policy/usage/usage_top2/policy_unname2.rs
@@ -29,21 +29,18 @@ pub fn start_task(args: &mut StartArgs) {
         args.controller.update_max_usage_tid();
         let Some(tid1) = args.controller.first_max_tid() else {
             #[cfg(debug_assertions)]
-
             debug!("获取不到first max tid，直接循环");
-
             std::thread::sleep(Duration::from_millis(500));
             continue;
         };
 
         let Some(tid2) = args.controller.second_max_tid() else {
             #[cfg(debug_assertions)]
-
             debug!("获取不到second max tid，直接循环");
-
             std::thread::sleep(Duration::from_millis(500));
             continue;
         };
+
         #[cfg(debug_assertions)]
         debug!("负载第一高:{tid1}\n第二高:{tid2}");
         execute_policy(task_map, tid1, tid2);


### PR DESCRIPTION
优化从task_map过滤线程部分的可读性，以及调参，平衡开销和体验