### PR TITLE
适配新游，性能优化

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ inotify = { version = "0.11.0", default-features = false }
 libc = "0.2.169"
 likely_stable = "0.1.3"
 log = "0.4.25"
-memchr = "2.7.4"
 mimalloc = { version = "0.1.43", features = ["local_dynamic_tls", "no_thp", "override"] }
 minstant = "0.1.7"
 once_cell = { version = "1.20.3", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,11 +8,6 @@ license = "GPL-3.0"
 readme = "README.md"
 repository = "https://github.com/reigadegr/thread-opt"
 
-[features]
-default = ["std"]
-std = []
-net = []
-
 [[bin]]
 name = "thread-opt"
 path = "src/main.rs"
@@ -23,19 +18,19 @@ path = "src/main.rs"
 # crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
-anyhow = "1.0.95"
-atoi = "2.0.0"
-compact_str = "0.8.1"
+anyhow = { version = "1.0.95", default-features = false }
+atoi = { version = "2.0.0", default-features = false }
+compact_str = { version = "0.8.1", default-features = false }
 dumpsys-rs = { git = "https://github.com/reigadegr/dumpsys-rs" }
-hashbrown = "0.15.2"
+hashbrown = "0.15.2" 
 inotify = { version = "0.11.0", default-features = false }
-libc = "0.2.169"
+libc = { version = "0.2.170", default-features = false }
 likely_stable = "0.1.3"
-log = "0.4.25"
+log = "0.4.26"
 mimalloc = { version = "0.1.43", features = ["local_dynamic_tls", "no_thp", "override"] }
 minstant = "0.1.7"
 once_cell = { version = "1.20.3", default-features = false }
-stringzilla = "3.11.3"
+stringzilla = "3.12.0"
 tklog = "0.2.9"
 
 [build-dependencies]

--- a/module/service.sh
+++ b/module/service.sh
@@ -9,7 +9,15 @@ wait_until_login() {
     until [ -d /sdcard/Android ]; do sleep 1; done
 }
 
-wait_until_login
+if [ "$(getprop sys.boot_completed)" != "1" ]; then
+    wait_until_login
+    stop oiface
+    stop gameopt_hal_service-1-0
+    stop vendor.urcc-hal-aidl
+    stop horae
+    killall -9 vendor.oplus.hardware.urcc-service vendor.oplus.hardware.gameopt-service oiface horae
+fi
+
 killall -15 thread-opt; rm $LOG
 chmod +x ${0%/*}/thread-opt
 RUST_BACKTRACE=1 nohup $MODDIR/thread-opt >$LOG 2>&1 &

--- a/release.sh
+++ b/release.sh
@@ -3,5 +3,4 @@ cargo fmt
 sed -i 's/edition = "2024"/edition = "2021"/g' Cargo.toml
 rm -rf output
 rm -rf $(find ./target/aarch64-linux-android/release -name "*thread-opt*")
-cargo fmt
 RUSTFLAGS="-C default-linker-libraries" python3 ./make.py build --release --nightly

--- a/src/activity/get_tid_info.rs
+++ b/src/activity/get_tid_info.rs
@@ -76,7 +76,7 @@ impl TidUtils {
         let mut task_map: HashMap<pid_t, [u8; 16]> = HashMap::new();
         for tid in tid_list {
             let comm_path = format!("/proc/{tid}/comm");
-            let Ok(comm) = read_to_byte(&comm_path) else {
+            let Ok(comm) = read_to_byte::<16>(&comm_path) else {
                 return &self.tid_info;
             };
             task_map.insert(tid, comm);

--- a/src/activity/get_tid_info.rs
+++ b/src/activity/get_tid_info.rs
@@ -100,11 +100,10 @@ fn read_task_dir(pid: pid_t) -> Result<Vec<pid_t>> {
     let c_path = CString::new(task_dir)?;
 
     let dir = unsafe { opendir(c_path.as_ptr()) };
-    let _dir_ptr_guard = DirGuard::new(dir);
     if unlikely(dir.is_null()) {
         return Err(anyhow!("Cannot read task_dir."));
     }
-
+    let _dir_ptr_guard = DirGuard::new(dir);
     let entries: Vec<_> = unsafe {
         let dir_ptr = dir;
 

--- a/src/activity/get_tid_info.rs
+++ b/src/activity/get_tid_info.rs
@@ -110,12 +110,12 @@ fn read_task_dir(pid: pid_t) -> Result<Vec<pid_t>> {
         std::iter::from_fn(move || {
             let entry = readdir(dir_ptr);
             if unlikely(entry.is_null()) {
-                return None;
+                return Some(0);
             }
 
             let d_name_ptr = (*entry).d_name.as_ptr();
-            // 这里，d_name_ptr长度不可能超过7
-            let bytes = std::slice::from_raw_parts(d_name_ptr, 7);
+            // 这里，d_name_ptr长度不可能超过6,Linux PID最大32768
+            let bytes = std::slice::from_raw_parts(d_name_ptr, 6);
             // 如果以'.'开头，会被fallback为0，最后被过滤
             Some(atoi::<pid_t>(bytes).unwrap_or(0))
         })

--- a/src/activity/get_tid_info.rs
+++ b/src/activity/get_tid_info.rs
@@ -110,7 +110,7 @@ fn read_task_dir(pid: pid_t) -> Result<Vec<pid_t>> {
         std::iter::from_fn(move || {
             let entry = readdir(dir_ptr);
             if unlikely(entry.is_null()) {
-                return Some(0);
+                return None;
             }
 
             let d_name_ptr = (*entry).d_name.as_ptr();

--- a/src/activity/get_tid_info.rs
+++ b/src/activity/get_tid_info.rs
@@ -9,7 +9,7 @@ use likely_stable::unlikely;
 use minstant::Instant;
 use stringzilla::sz;
 extern crate alloc;
-use alloc::{ffi::CString, format};
+use alloc::{ffi::CString, format, vec::Vec};
 
 #[derive(Default)]
 pub struct TidInfo {
@@ -138,6 +138,5 @@ pub fn get_process_name(pid: pid_t) -> Result<CompactString> {
     let buffer = pos.map_or(&buffer[..], |pos| &buffer[..pos]);
 
     let buffer = CompactString::from_utf8(buffer)?;
-    println!("经计算后的包名:{buffer}");
     Ok(buffer)
 }

--- a/src/activity/get_tid_info.rs
+++ b/src/activity/get_tid_info.rs
@@ -7,10 +7,9 @@ use hashbrown::HashMap;
 use libc::{opendir, pid_t, readdir};
 use likely_stable::unlikely;
 use minstant::Instant;
-use std::ffi::CString;
 use stringzilla::sz;
 extern crate alloc;
-use alloc::format;
+use alloc::{ffi::CString, format};
 
 #[derive(Default)]
 pub struct TidInfo {

--- a/src/activity/get_tid_info.rs
+++ b/src/activity/get_tid_info.rs
@@ -7,7 +7,7 @@ use hashbrown::HashMap;
 use libc::{closedir, opendir, pid_t, readdir};
 use likely_stable::unlikely;
 use minstant::Instant;
-use std::{ffi::CString, fs, io::Read, path::Path};
+use std::{ffi::CString, fs, io::Read};
 use stringzilla::sz;
 extern crate alloc;
 use alloc::format;
@@ -131,7 +131,7 @@ fn read_task_dir(pid: pid_t) -> Result<Vec<pid_t>> {
 }
 
 pub fn get_process_name(pid: pid_t) -> Result<CompactString> {
-    let cmdline = Path::new("/proc").join(pid.to_string()).join("cmdline");
+    let cmdline = format!("/proc/{pid}/cmdline");
     let mut cmdline = fs::File::open(cmdline)?;
     let mut buffer = [0u8; 128];
     let _ = cmdline.read(&mut buffer)?;

--- a/src/activity/get_tid_info.rs
+++ b/src/activity/get_tid_info.rs
@@ -107,7 +107,7 @@ fn read_task_dir(pid: pid_t) -> Result<Vec<pid_t>> {
 
     let entries: Vec<_> = unsafe {
         let dir_ptr = dir;
-        std::iter::from_fn(move || {
+        core::iter::from_fn(move || {
             let entry = readdir(dir_ptr);
             if unlikely(entry.is_null()) {
                 return None;
@@ -115,7 +115,7 @@ fn read_task_dir(pid: pid_t) -> Result<Vec<pid_t>> {
 
             let d_name_ptr = (*entry).d_name.as_ptr();
             // 这里，d_name_ptr长度不可能超过6,Linux PID最大32768
-            let bytes = std::slice::from_raw_parts(d_name_ptr, 6);
+            let bytes = core::slice::from_raw_parts(d_name_ptr, 6);
             // 如果以'.'开头，会被fallback为0，最后被过滤
             Some(atoi::<pid_t>(bytes).unwrap_or(0))
         })

--- a/src/activity/get_tid_info.rs
+++ b/src/activity/get_tid_info.rs
@@ -7,7 +7,7 @@ use hashbrown::HashMap;
 use libc::{opendir, pid_t, readdir};
 use likely_stable::unlikely;
 use minstant::Instant;
-use std::{ffi::CString, fs, io::Read};
+use std::ffi::CString;
 use stringzilla::sz;
 extern crate alloc;
 use alloc::format;
@@ -127,10 +127,7 @@ fn read_task_dir(pid: pid_t) -> Result<Vec<pid_t>> {
 
 pub fn get_process_name(pid: pid_t) -> Result<CompactString> {
     let cmdline = format!("/proc/{pid}/cmdline");
-    let mut cmdline = fs::File::open(cmdline)?;
-    let mut buffer = [0u8; 128];
-    let _ = cmdline.read(&mut buffer)?;
-
+    let buffer = read_to_byte::<128>(&cmdline)?;
     let pos = sz::find(buffer, b":");
     if let Some(sub) = pos {
         let buffer = &buffer[..sub];
@@ -142,5 +139,6 @@ pub fn get_process_name(pid: pid_t) -> Result<CompactString> {
     let buffer = pos.map_or(&buffer[..], |pos| &buffer[..pos]);
 
     let buffer = CompactString::from_utf8(buffer)?;
+    println!("经计算后的包名:{buffer}");
     Ok(buffer)
 }

--- a/src/activity/get_top_pid.rs
+++ b/src/activity/get_top_pid.rs
@@ -24,8 +24,6 @@ impl TopPidInfo {
             })
             .and_then(atoi::<pid_t>)
             .unwrap_or_default();
-        #[cfg(debug_assertions)]
-        println!("pid为-{pid:?}-");
         Self { pid }
     }
 }

--- a/src/activity/get_top_pid.rs
+++ b/src/activity/get_top_pid.rs
@@ -59,7 +59,7 @@ impl TopAppUtils {
     pub fn set_top_pid(&mut self) -> TopPidInfo {
         self.inotify.read_events_blocking(&mut [0; 1024]).unwrap();
         #[cfg(debug_assertions)]
-        let start = std::time::Instant::now();
+        let start = minstant::Instant::now();
         let dump = loop {
             match self.dumper.dump_to_byte(&["lru"]) {
                 Ok(dump) => break dump,

--- a/src/activity/get_top_pid.rs
+++ b/src/activity/get_top_pid.rs
@@ -59,7 +59,7 @@ impl TopAppUtils {
         #[cfg(debug_assertions)]
         let start = minstant::Instant::now();
         let dump = loop {
-            match self.dumper.dump_to_byte(&["lru"]) {
+            match self.dumper.dump_to_byte::<1024>(&["lru"]) {
                 Ok(dump) => break dump,
                 Err(e) => {
                     info!("Failed to dump windows: {}, retrying", e);

--- a/src/activity/get_top_pid.rs
+++ b/src/activity/get_top_pid.rs
@@ -1,4 +1,4 @@
-use crate::utils::sleep::sleep_millis;
+use crate::utils::sleep::sleep_secs;
 use atoi::atoi;
 use dumpsys_rs::Dumpsys;
 use inotify::{Inotify, WatchMask};
@@ -46,7 +46,7 @@ impl TopAppUtils {
         let dumper = loop {
             match Dumpsys::new("activity") {
                 Some(d) => break d,
-                None => sleep_millis(500),
+                None => sleep_secs(1),
             }
         };
         Self { dumper, inotify }
@@ -65,7 +65,7 @@ impl TopAppUtils {
                 Ok(dump) => break dump,
                 Err(e) => {
                     info!("Failed to dump windows: {}, retrying", e);
-                    sleep_millis(500);
+                    sleep_secs(1);
                 }
             }
         };

--- a/src/cgroup/analysis.rs
+++ b/src/cgroup/analysis.rs
@@ -63,7 +63,6 @@ pub fn analysis_cgroup_new(target_core: &str) -> Result<Box<[u8]>> {
                 entries.push(entry_name.to_owned());
             }
         }
-
         // 关闭目录
         closedir(dir_ptr);
     }
@@ -103,10 +102,10 @@ pub fn analysis_cgroup_new(target_core: &str) -> Result<Box<[u8]>> {
                         let end = start.elapsed();
                         log::debug!("读目录时间: {:?}", end);
                     }
+                    closedir(dir_ptr);
                     return rs;
                 }
             }
-
             closedir(dir_ptr);
         }
     }

--- a/src/cgroup/analysis.rs
+++ b/src/cgroup/analysis.rs
@@ -8,11 +8,17 @@ use once_cell::sync::Lazy;
 extern crate alloc;
 use alloc::{boxed::Box, vec::Vec};
 
-pub static TOP_GROUP: Lazy<Box<[u8]>> = Lazy::new(|| analysis_cgroup_new("7").unwrap());
+pub static TOP_GROUP: Lazy<&'static [u8]> = Lazy::new(|| {
+    let data = analysis_cgroup_new("7").unwrap();
+    Box::leak(data)
+});
 
-pub static BACKEND_GROUP: Lazy<Box<[u8]>> = Lazy::new(|| analysis_cgroup_new("0").unwrap());
+pub static BACKEND_GROUP: Lazy<&'static [u8]> = Lazy::new(|| {
+    let data = analysis_cgroup_new("0").unwrap();
+    Box::leak(data)
+});
 
-pub static MIDDLE_GROUP: Lazy<Box<[u8]>> = Lazy::new(|| {
+pub static MIDDLE_GROUP: Lazy<&'static [u8]> = Lazy::new(|| {
     let mut all_core: Vec<u8> = [0, 1, 2, 3, 4, 5, 6, 7].to_vec();
     let background_values = get_background_group();
     let top_values = get_top_group();
@@ -21,13 +27,14 @@ pub static MIDDLE_GROUP: Lazy<Box<[u8]>> = Lazy::new(|| {
         all_core.retain(|&x| x != value);
     }
 
-    if all_core.is_empty() {
+    let data = if all_core.is_empty() {
         info!("MIDDLE_GROUP initializing with BACKEND_GROUP.");
         background_values.into()
     } else {
         // 否则，使用处理后的 all_core 初始化 MIDDLE_GROUP
         all_core.into_boxed_slice()
-    }
+    };
+    Box::leak(data)
 });
 
 pub fn analysis_cgroup_new(target_core: &str) -> Result<Box<[u8]>> {

--- a/src/cgroup/analysis.rs
+++ b/src/cgroup/analysis.rs
@@ -87,13 +87,13 @@ pub fn analysis_cgroup_new(target_core: &str) -> Result<Box<[u8]>> {
                 }
                 let d_name_ptr = (*entry_ptr).d_name.as_ptr();
                 // 这里，最大为related_cpus的长度，12
-                let bytes = std::slice::from_raw_parts(d_name_ptr, 12);
+                let bytes = core::slice::from_raw_parts(d_name_ptr, 12);
 
                 if likely(sz::find(bytes, b"related_cpus").is_none()) {
                     continue;
                 }
 
-                let bytes = std::str::from_utf8(bytes)?;
+                let bytes = core::str::from_utf8(bytes)?;
                 let bytes = format!("{}/{bytes}", entry.to_str()?);
                 let content = read_file(&bytes).unwrap_or_else(|_| CompactString::new("8"));
                 // 解析文件内容

--- a/src/cgroup/analysis.rs
+++ b/src/cgroup/analysis.rs
@@ -8,17 +8,11 @@ use once_cell::sync::Lazy;
 extern crate alloc;
 use alloc::{boxed::Box, vec::Vec};
 
-pub static TOP_GROUP: Lazy<&'static [u8]> = Lazy::new(|| {
-    let data = analysis_cgroup_new("7").unwrap();
-    Box::leak(data)
-});
+pub static TOP_GROUP: Lazy<Box<[u8]>> = Lazy::new(|| analysis_cgroup_new("7").unwrap());
 
-pub static BACKEND_GROUP: Lazy<&'static [u8]> = Lazy::new(|| {
-    let data = analysis_cgroup_new("0").unwrap();
-    Box::leak(data)
-});
+pub static BACKEND_GROUP: Lazy<Box<[u8]>> = Lazy::new(|| analysis_cgroup_new("0").unwrap());
 
-pub static MIDDLE_GROUP: Lazy<&'static [u8]> = Lazy::new(|| {
+pub static MIDDLE_GROUP: Lazy<Box<[u8]>> = Lazy::new(|| {
     let mut all_core: Vec<u8> = [0, 1, 2, 3, 4, 5, 6, 7].to_vec();
     let background_values = get_background_group();
     let top_values = get_top_group();
@@ -27,14 +21,13 @@ pub static MIDDLE_GROUP: Lazy<&'static [u8]> = Lazy::new(|| {
         all_core.retain(|&x| x != value);
     }
 
-    let data = if all_core.is_empty() {
+    if all_core.is_empty() {
         info!("MIDDLE_GROUP initializing with BACKEND_GROUP.");
         background_values.into()
     } else {
         // 否则，使用处理后的 all_core 初始化 MIDDLE_GROUP
         all_core.into_boxed_slice()
-    };
-    Box::leak(data)
+    }
 });
 
 pub fn analysis_cgroup_new(target_core: &str) -> Result<Box<[u8]>> {

--- a/src/cgroup/analysis.rs
+++ b/src/cgroup/analysis.rs
@@ -6,10 +6,9 @@ use libc::{DT_DIR, opendir, readdir};
 use likely_stable::{likely, unlikely};
 use log::info;
 use once_cell::sync::Lazy;
-use std::ffi::CString;
 use stringzilla::sz;
 extern crate alloc;
-use alloc::{boxed::Box, vec::Vec};
+use alloc::{boxed::Box, ffi::CString, vec::Vec};
 
 pub static TOP_GROUP: Lazy<Box<[u8]>> = Lazy::new(|| analysis_cgroup_new("7").unwrap());
 

--- a/src/cgroup/analysis.rs
+++ b/src/cgroup/analysis.rs
@@ -36,12 +36,11 @@ fn read_cgroup_dir() -> Result<Vec<CString>> {
     let cgroup = "/sys/devices/system/cpu/cpufreq";
     let cgroup = CString::new(cgroup)?;
     let dir = unsafe { opendir(cgroup.as_ptr()) };
-    let _dir_ptr_guard = DirGuard::new(dir);
 
     if unlikely(dir.is_null()) {
         return Err(anyhow!("Cannot read task_dir."));
     }
-
+    let _dir_ptr_guard = DirGuard::new(dir);
     let mut entries = Vec::new();
     unsafe {
         let dir_ptr = dir;
@@ -78,11 +77,12 @@ pub fn analysis_cgroup_new(target_core: &str) -> Result<Box<[u8]>> {
     let entries = read_cgroup_dir()?;
     for entry in entries {
         let core_dir_ptr = unsafe { opendir(entry.as_ptr()) };
-        let _dir_ptr_guard = DirGuard::new(core_dir_ptr);
 
         if unlikely(core_dir_ptr.is_null()) {
             return Err(anyhow!("Cannot read cgroup dir."));
         }
+
+        let _dir_ptr_guard = DirGuard::new(core_dir_ptr);
 
         unsafe {
             let dir_ptr = core_dir_ptr;

--- a/src/cgroup/analysis.rs
+++ b/src/cgroup/analysis.rs
@@ -8,7 +8,7 @@ use log::info;
 use once_cell::sync::Lazy;
 use stringzilla::sz;
 extern crate alloc;
-use alloc::{boxed::Box, ffi::CString, vec::Vec};
+use alloc::{boxed::Box, ffi::CString, format, vec::Vec};
 
 pub static TOP_GROUP: Lazy<Box<[u8]>> = Lazy::new(|| analysis_cgroup_new("7").unwrap());
 

--- a/src/cgroup/analysis.rs
+++ b/src/cgroup/analysis.rs
@@ -61,8 +61,6 @@ fn read_cgroup_dir() -> Result<Vec<String>> {
                 entries.push(entry_name.to_string());
             }
         }
-        // 关闭目录
-        // closedir(dir_ptr);
     }
     Ok(entries)
 }

--- a/src/cpu_common/usage_tracker.rs
+++ b/src/cpu_common/usage_tracker.rs
@@ -2,6 +2,8 @@ use crate::utils::node_reader::read_to_byte;
 use atoi::atoi;
 use libc::pid_t;
 use stringzilla::sz;
+extern crate alloc;
+use alloc::format;
 
 #[derive(Debug, Clone)]
 pub struct UsageTracker {

--- a/src/cpu_common/usage_tracker.rs
+++ b/src/cpu_common/usage_tracker.rs
@@ -1,6 +1,6 @@
+use crate::utils::node_reader::read_to_byte;
 use atoi::atoi;
 use libc::pid_t;
-use std::{fs::File, io::Read};
 use stringzilla::sz;
 
 #[derive(Debug, Clone)]
@@ -20,16 +20,8 @@ impl UsageTracker {
 
 fn get_thread_cpu_time(tid: pid_t) -> u64 {
     let stat_path = format!("/proc/{tid}/schedstat");
-    let Ok(mut file) = File::open(&stat_path) else {
-        return 0;
-    };
-    let mut buffer = [0u8; 32];
-    let Ok(_) = file.read(&mut buffer) else {
-        return 0;
-    };
-
+    let buffer = read_to_byte::<32>(&stat_path).unwrap_or([0u8; 32]);
     let pos = sz::find(buffer, b" ");
     let buffer = pos.map_or(&buffer[..], |pos| &buffer[..pos]);
-
     atoi::<u64>(buffer).unwrap_or(0)
 }

--- a/src/cpu_common/usage_tracker.rs
+++ b/src/cpu_common/usage_tracker.rs
@@ -1,6 +1,6 @@
 use atoi::atoi;
 use libc::pid_t;
-use std::{fs::File, io::Read, path::Path};
+use std::{fs::File, io::Read};
 use stringzilla::sz;
 
 #[derive(Debug, Clone)]
@@ -19,7 +19,7 @@ impl UsageTracker {
 }
 
 fn get_thread_cpu_time(tid: pid_t) -> u64 {
-    let stat_path = Path::new("/proc").join(tid.to_string()).join("schedstat");
+    let stat_path = format!("/proc/{tid}/schedstat");
     let Ok(mut file) = File::open(&stat_path) else {
         return 0;
     };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// #![no_std]
+#![no_std]
 #![no_main]
 #![deny(clippy::pedantic)]
 #![warn(clippy::nursery)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+#![no_std]
 #![deny(clippy::pedantic)]
 #![warn(clippy::nursery)]
 #![allow(clippy::non_std_lazy_statics)]

--- a/src/misc/mod.rs
+++ b/src/misc/mod.rs
@@ -6,7 +6,7 @@ use likely_stable::unlikely;
 use log::info;
 use logger::{init_log, log_metainfo};
 extern crate alloc;
-use alloc::ffi::CString;
+use alloc::{ffi::CString, string::ToString};
 
 pub fn init_misc() {
     working_in_background();

--- a/src/misc/mod.rs
+++ b/src/misc/mod.rs
@@ -1,6 +1,7 @@
 pub mod logger;
-use crate::cgroup::group_info::print_group_core;
+use crate::{cgroup::group_info::print_group_core, utils::node_reader::write_to_byte};
 use anyhow::Result;
+use libc::getpid;
 use likely_stable::unlikely;
 use log::info;
 use logger::{init_log, log_metainfo};
@@ -20,8 +21,10 @@ pub fn init_misc() {
 }
 
 fn working_in_background() {
-    let self_pid = std::process::id();
-    let _ = std::fs::write("/dev/cpuset/background/tasks", self_pid.to_string());
+    unsafe {
+        let self_pid = getpid().to_string();
+        let _ = write_to_byte::<6>("/dev/cpuset/background/tasks", &self_pid);
+    }
 }
 
 fn set_main_thread_name(name: &str) -> Result<()> {

--- a/src/misc/mod.rs
+++ b/src/misc/mod.rs
@@ -41,4 +41,5 @@ fn set_main_thread_name(name: &str) -> Result<()> {
 fn print_misc() {
     info!("免费软件，禁止商用");
     info!("Free software, not for commercial use.");
+    info!("开源地址: https://github.com/reigadegr/thread-opt");
 }

--- a/src/policy/name_match/mod.rs
+++ b/src/policy/name_match/mod.rs
@@ -1,7 +1,7 @@
 mod common;
 pub mod policies;
 
-use crate::{policy::pkg_cfg::StartArgs, utils::sleep::sleep_millis};
+use crate::{policy::pkg_cfg::StartArgs, utils::sleep::sleep_secs};
 use common::Policy;
 use likely_stable::unlikely;
 #[cfg(debug_assertions)]
@@ -24,7 +24,7 @@ impl<'b, 'a: 'b> StartTask<'b, 'a> {
 
     fn start_task(&mut self) {
         loop {
-            sleep_millis(2000);
+            sleep_secs(2);
             let pid = self.args.activity_utils.top_app_utils.get_top_pid();
             if unlikely(pid != self.args.pid) {
                 return;

--- a/src/policy/pkg_cfg.rs
+++ b/src/policy/pkg_cfg.rs
@@ -1,7 +1,7 @@
 use super::{
     name_match::policies::{policy_sky, policy_ue, policy_unity},
     usage_top1::policies::{
-        policy_cocos, policy_top1, policy_ue5, policy_unity_t1, policy_unity_t1_u2,
+        policy_cocos, policy_top1, policy_ue5, policy_unity_t1, policy_unity_t1_u2, policy_wzm,
     },
     usage_top2::{policy_party, policy_top2, policy_ue_t2, policy_unity_t2},
 };
@@ -9,7 +9,7 @@ use crate::activity::ActivityUtils;
 use libc::pid_t;
 
 // 对于普通的Unity游戏
-const UNITY: [&str; 13] = [
+const UNITY: [&str; 12] = [
     "com.miHoYo.Yuanshen",
     "com.miHoYo.GenshinImpact",
     "com.miHoYo.ys.bilibili",
@@ -21,15 +21,11 @@ const UNITY: [&str; 13] = [
     "com.tencent.tmgp.sgame",
     "com.miHoYo.Nap",
     "com.yongshi.tenojo.ys",
-    "com.tencent.tmgp.speedmobile",
     "com.tencent.KiHan",
 ];
 
 // 单纯的的线程名匹配，对于ue游戏
 const UE: [&str; 1] = ["com.kurogame.mingchao"];
-
-// 单纯的的线程名匹配，对于光遇游戏
-const SKY_T2: [&str; 1] = ["com.netease.sky"];
 
 // 对于需要取一个cputime最大的线程，其线程前缀名为"Thread-"
 const UE_T1: [&str; 2] = ["com.tencent.lzhx", "com.tencent.tmgp.pubgmhd"];
@@ -37,17 +33,23 @@ const UE_T1: [&str; 2] = ["com.tencent.lzhx", "com.tencent.tmgp.pubgmhd"];
 // 需要取一个cputime最大的线程，其线程前缀名为"GameThread"，只有无限暖暖
 const UE5_T1: [&str; 1] = ["com.papegames.infinitynikki"];
 
+// cod战区，负载最重线程为WZM_Main
+const WZM_T1: [&str; 1] = ["com.activision.callofduty.warzone"];
+
 // 对于三国杀，跟暖暖策略一样，只是线程名不同
 const COCOS_T1: [&str; 1] = ["com.bf.sgs.hdexp"];
 
 // 需要取一个cputime第二大的线程，其线程前缀名为"Thread-"，且为unity游戏
-const UNITY_T1_U2: [&str; 1] = ["com.tencent.lolm"];
+const UNITY_T1_U2: [&str; 2] = ["com.tencent.lolm", "com.tencent.tmgp.speedmobile"];
 
 // 需要单独把负载最重的unitymain绑定到cpu7
 const UNITY_T1: [&str; 2] = ["com.tencent.tmgp.cod", "com.tencent.tmgp.cf"];
 
 // 对于需要取两个重负载线程的游戏，其线程前缀名均为"Thread-"，目前策略是燕云十六声特调
 const USAGE_T2: [&str; 1] = ["com.netease.yyslscn"];
+
+// 单纯的的线程名匹配，对于光遇游戏
+const SKY_T2: [&str; 1] = ["com.netease.sky"];
 
 // 对于需要取两个重负载线程的游戏，其线程前缀名分别为"Thread-"，"MainThread"，目前策略是蛋仔派对特调
 const PARTY_T2: [&str; 1] = ["com.netease.party"];
@@ -68,7 +70,7 @@ pub struct StartArgs<'a> {
 
 type ConfigTuple = (&'static [&'static str], fn(&mut StartArgs));
 
-pub const PACKAGE_CONFIGS: [ConfigTuple; 12] = [
+pub const PACKAGE_CONFIGS: [ConfigTuple; 13] = [
     (&UE_T1, policy_top1::start_task),
     (&USAGE_T2, policy_top2::start_task),
     (&UNITY_T2, policy_unity_t2::start_task),
@@ -78,6 +80,7 @@ pub const PACKAGE_CONFIGS: [ConfigTuple; 12] = [
     (&UE_T2, policy_ue_t2::start_task),
     (&SKY_T2, policy_sky::start_task),
     (&UE5_T1, policy_ue5::start_task),
+    (&WZM_T1, policy_wzm::start_task),
     (&COCOS_T1, policy_cocos::start_task),
     (&UNITY_T1_U2, policy_unity_t1_u2::start_task),
     (&UNITY_T1, policy_unity_t1::start_task),

--- a/src/policy/pkg_cfg.rs
+++ b/src/policy/pkg_cfg.rs
@@ -39,11 +39,11 @@ const WZM_T1: [&str; 1] = ["com.activision.callofduty.warzone"];
 // 对于三国杀，跟暖暖策略一样，只是线程名不同
 const COCOS_T1: [&str; 1] = ["com.bf.sgs.hdexp"];
 
-// 需要取一个cputime第二大的线程，其线程前缀名为"Thread-"，且为unity游戏
-const UNITY_T1_U2: [&str; 2] = ["com.tencent.lolm", "com.tencent.tmgp.speedmobile"];
-
 // 需要单独把负载最重的unitymain绑定到cpu7
 const UNITY_T1: [&str; 2] = ["com.tencent.tmgp.cod", "com.tencent.tmgp.cf"];
+
+// 需要取一个cputime第二大的线程，其线程前缀名为"Thread-"，且为unity游戏
+const UNITY_T1_U2: [&str; 2] = ["com.tencent.lolm", "com.tencent.tmgp.speedmobile"];
 
 // 对于需要取两个重负载线程的游戏，其线程前缀名均为"Thread-"，目前策略是燕云十六声特调
 const USAGE_T2: [&str; 1] = ["com.netease.yyslscn"];
@@ -71,17 +71,17 @@ pub struct StartArgs<'a> {
 type ConfigTuple = (&'static [&'static str], fn(&mut StartArgs));
 
 pub const PACKAGE_CONFIGS: [ConfigTuple; 13] = [
-    (&UE_T1, policy_top1::start_task),
-    (&USAGE_T2, policy_top2::start_task),
-    (&UNITY_T2, policy_unity_t2::start_task),
-    (&PARTY_T2, policy_party::start_task),
-    (&UNITY, policy_unity::start_task),
     (&UE, policy_ue::start_task),
-    (&UE_T2, policy_ue_t2::start_task),
-    (&SKY_T2, policy_sky::start_task),
+    (&UNITY, policy_unity::start_task),
+    (&UE_T1, policy_top1::start_task),
     (&UE5_T1, policy_ue5::start_task),
     (&WZM_T1, policy_wzm::start_task),
     (&COCOS_T1, policy_cocos::start_task),
-    (&UNITY_T1_U2, policy_unity_t1_u2::start_task),
     (&UNITY_T1, policy_unity_t1::start_task),
+    (&UNITY_T1_U2, policy_unity_t1_u2::start_task),
+    (&USAGE_T2, policy_top2::start_task),
+    (&UNITY_T2, policy_unity_t2::start_task),
+    (&PARTY_T2, policy_party::start_task),
+    (&UE_T2, policy_ue_t2::start_task),
+    (&SKY_T2, policy_sky::start_task),
 ];

--- a/src/policy/pkg_cfg.rs
+++ b/src/policy/pkg_cfg.rs
@@ -1,7 +1,8 @@
 use super::{
     name_match::policies::{policy_sky, policy_ue, policy_unity},
     usage_top1::policies::{
-        policy_cocos, policy_top1, policy_ue5, policy_unity_t1, policy_unity_t1_u2, policy_wzm,
+        policy_cocos, policy_ru, policy_top1, policy_ue5, policy_unity_t1, policy_unity_t1_u2,
+        policy_wzm,
     },
     usage_top2::{policy_party, policy_top2, policy_ue_t2, policy_unity_t2},
 };
@@ -32,6 +33,9 @@ const UE_T1: [&str; 2] = ["com.tencent.lzhx", "com.tencent.tmgp.pubgmhd"];
 
 // 需要取一个cputime最大的线程，其线程前缀名为"GameThread"，只有无限暖暖
 const UE5_T1: [&str; 1] = ["com.papegames.infinitynikki"];
+
+//拉力竞速3
+const RU_T1: [&str; 1] = ["brownmonster.app.game.rushrally3"];
 
 // cod战区，负载最重线程为WZM_Main
 const WZM_T1: [&str; 1] = ["com.activision.callofduty.warzone"];
@@ -71,12 +75,13 @@ pub struct StartArgs<'a> {
 
 type ConfigTuple = (&'static [&'static str], fn(&mut StartArgs));
 
-pub const PACKAGE_CONFIGS: [ConfigTuple; 13] = [
+pub const PACKAGE_CONFIGS: [ConfigTuple; 14] = [
     (&UE, policy_ue::start_task),
     (&UNITY, policy_unity::start_task),
     (&UE_T1, policy_top1::start_task),
     (&UE5_T1, policy_ue5::start_task),
     (&WZM_T1, policy_wzm::start_task),
+    (&RU_T1, policy_ru::start_task),
     (&COCOS_T1, policy_cocos::start_task),
     (&UNITY_T1, policy_unity_t1::start_task),
     (&UNITY_T1_U2, policy_unity_t1_u2::start_task),

--- a/src/policy/pkg_cfg.rs
+++ b/src/policy/pkg_cfg.rs
@@ -36,8 +36,8 @@ const UE5_T1: [&str; 1] = ["com.papegames.infinitynikki"];
 // cod战区，负载最重线程为WZM_Main
 const WZM_T1: [&str; 1] = ["com.activision.callofduty.warzone"];
 
-// 对于三国杀，跟暖暖策略一样，只是线程名不同
-const COCOS_T1: [&str; 1] = ["com.bf.sgs.hdexp"];
+// 对于三国杀和时空猎人，跟暖暖策略一样，只是线程名不同
+const COCOS_T1: [&str; 2] = ["com.bf.sgs.hdexp", "com.yinhan.hunter.tx"];
 
 // 需要单独把负载最重的unitymain绑定到cpu7
 const UNITY_T1: [&str; 2] = ["com.tencent.tmgp.cod", "com.tencent.tmgp.cf"];

--- a/src/policy/pkg_cfg.rs
+++ b/src/policy/pkg_cfg.rs
@@ -54,10 +54,11 @@ const SKY_T2: [&str; 1] = ["com.netease.sky"];
 // 对于需要取两个重负载线程的游戏，其线程前缀名分别为"Thread-"，"MainThread"，目前策略是蛋仔派对特调
 const PARTY_T2: [&str; 1] = ["com.netease.party"];
 
-// 对于需要取两个重负载线程的游戏，其线程前缀名分别为"Thread-"，"UnityMain"
-const UNITY_T2: [&str; 2] = [
+// 对于需要取两个重负载线程的游戏，其线程前缀名分别为"UnityMain","Thread-"
+const UNITY_T2: [&str; 3] = [
     "com.galasports.operablebasketball.mi",
     "com.sofunny.Sausage",
+    "com.tencent.jkchess",
 ];
 
 // 对于需要取两个重负载线程的游戏，其线程前缀名分别为"GameThread","RenderThread"，目前策略只有三角洲

--- a/src/policy/usage_top1/mod.rs
+++ b/src/policy/usage_top1/mod.rs
@@ -2,8 +2,7 @@ pub mod common;
 pub mod policies;
 use super::get_thread_tids;
 use crate::{
-    cpu_common::process_monitor::get_top1_tid, policy::pkg_cfg::StartArgs,
-    utils::sleep::sleep_millis,
+    cpu_common::process_monitor::get_top1_tid, policy::pkg_cfg::StartArgs, utils::sleep::sleep_secs,
 };
 use common::{CmdType, Policy};
 use libc::pid_t;
@@ -54,7 +53,7 @@ impl<'b, 'a: 'b> StartTask<'b, 'a> {
 
     fn start_task(&mut self, comm_prefix: &[u8], cmd_type: &CmdType) {
         loop {
-            sleep_millis(2000);
+            sleep_secs(2);
             let pid = self.args.activity_utils.top_app_utils.get_top_pid();
             if unlikely(pid != self.args.pid) {
                 return;

--- a/src/policy/usage_top1/policies/mod.rs
+++ b/src/policy/usage_top1/policies/mod.rs
@@ -3,3 +3,4 @@ pub mod policy_top1;
 pub mod policy_ue5;
 pub mod policy_unity_t1;
 pub mod policy_unity_t1_u2;
+pub mod policy_wzm;

--- a/src/policy/usage_top1/policies/mod.rs
+++ b/src/policy/usage_top1/policies/mod.rs
@@ -1,4 +1,5 @@
 pub mod policy_cocos;
+pub mod policy_ru;
 pub mod policy_top1;
 pub mod policy_ue5;
 pub mod policy_unity_t1;

--- a/src/policy/usage_top1/policies/policy_cocos.rs
+++ b/src/policy/usage_top1/policies/policy_cocos.rs
@@ -1,7 +1,7 @@
 use super::super::top1_macro_init;
 
 const TOP: [&[u8]; 0] = [];
-const ONLY6: [&[u8]; 2] = [b"GLThread", b"binder"];
+const ONLY6: [&[u8]; 1] = [b"GLThread"];
 const ONLY7: [&[u8]; 0] = [];
 const MIDDLE: [&[u8]; 0] = [];
 const BACKEND: [&[u8]; 0] = [];

--- a/src/policy/usage_top1/policies/policy_ru.rs
+++ b/src/policy/usage_top1/policies/policy_ru.rs
@@ -1,0 +1,9 @@
+use super::super::top1_macro_init;
+
+const TOP: [&[u8]; 0] = [];
+const ONLY6: [&[u8]; 1] = [b"._RuMain"];
+const ONLY7: [&[u8]; 0] = [];
+const MIDDLE: [&[u8]; 1] = [b"mail-cmar"];
+const BACKEND: [&[u8]; 0] = [];
+
+top1_macro_init!(b"Thread-", Only7);

--- a/src/policy/usage_top1/policies/policy_wzm.rs
+++ b/src/policy/usage_top1/policies/policy_wzm.rs
@@ -1,0 +1,9 @@
+use super::super::top1_macro_init;
+
+const TOP: [&[u8]; 0] = [];
+const ONLY6: [&[u8]; 0] = [];
+const ONLY7: [&[u8]; 1] = [b"WZM_Main"];
+const MIDDLE: [&[u8]; 1] = [b"Worker"];
+const BACKEND: [&[u8]; 0] = [];
+
+top1_macro_init!(b"Thread-", Only6);

--- a/src/policy/usage_top2/mod.rs
+++ b/src/policy/usage_top2/mod.rs
@@ -8,7 +8,7 @@ use super::get_thread_tids;
 use crate::{
     cpu_common::process_monitor::{get_top1_tid, get_top2_tids},
     policy::pkg_cfg::StartArgs,
-    utils::sleep::sleep_millis,
+    utils::sleep::sleep_secs,
 };
 
 use common::execute_policy;
@@ -64,7 +64,7 @@ impl<'b, 'a: 'b> StartTask<'b, 'a> {
 
     fn start_task(&mut self, comm_prefix1: &[u8], comm_prefix2: Option<&[u8]>) {
         loop {
-            sleep_millis(2000);
+            sleep_secs(2);
 
             let pid = self.args.activity_utils.top_app_utils.get_top_pid();
             if unlikely(pid != self.args.pid) {

--- a/src/scheduler/looper.rs
+++ b/src/scheduler/looper.rs
@@ -1,7 +1,7 @@
 use crate::{
     activity::{ActivityUtils, get_tid_info::get_process_name},
     policy::pkg_cfg::{PACKAGE_CONFIGS, StartArgs},
-    utils::{affinity_utils::global_cpu_utils::bind_list_to_background, sleep::sleep_millis},
+    utils::{affinity_utils::global_cpu_utils::bind_list_to_background, sleep::sleep_secs},
 };
 use compact_str::CompactString;
 use libc::pid_t;
@@ -58,7 +58,7 @@ impl Looper {
 
     pub fn enter_loop(&mut self) {
         'outer: loop {
-            sleep_millis(1000);
+            sleep_secs(1);
             {
                 let pid = self.activity_utils.top_app_utils.get_top_pid();
                 if self.pid == pid {

--- a/src/utils/guard.rs
+++ b/src/utils/guard.rs
@@ -1,5 +1,6 @@
+use anyhow::{Result, anyhow};
 use core::ptr::NonNull;
-use libc::{DIR, closedir};
+use libc::{DIR, c_int, close, closedir};
 
 pub struct DirGuard(Option<NonNull<DIR>>);
 
@@ -8,16 +9,33 @@ impl DirGuard {
     pub const fn new(dir: *mut DIR) -> Self {
         Self(NonNull::new(dir))
     }
+}
+
+impl Drop for DirGuard {
     /// 关闭目录并释放资源。
-    pub fn close(&mut self) {
+    fn drop(&mut self) {
         if let Some(dir) = self.0.take() {
             let _ = unsafe { closedir(dir.as_ptr()) };
         }
     }
 }
 
-impl Drop for DirGuard {
+pub struct FileGuard(c_int);
+
+impl FileGuard {
+    pub fn new(fd: c_int) -> Result<Self> {
+        if fd == -1 {
+            Err(anyhow!("Cannot open file."))
+        } else {
+            Ok(Self(fd))
+        }
+    }
+}
+
+impl Drop for FileGuard {
     fn drop(&mut self) {
-        self.close();
+        if self.0 != -1 {
+            unsafe { close(self.0) };
+        }
     }
 }

--- a/src/utils/guard.rs
+++ b/src/utils/guard.rs
@@ -1,4 +1,3 @@
-use anyhow::{Result, anyhow};
 use core::ptr::NonNull;
 use libc::{DIR, c_int, close, closedir};
 
@@ -23,19 +22,13 @@ impl Drop for DirGuard {
 pub struct FileGuard(c_int);
 
 impl FileGuard {
-    pub fn new(fd: c_int) -> Result<Self> {
-        if fd == -1 {
-            Err(anyhow!("Cannot open file."))
-        } else {
-            Ok(Self(fd))
-        }
+    pub const fn new(fd: c_int) -> Self {
+        Self(fd)
     }
 }
 
 impl Drop for FileGuard {
     fn drop(&mut self) {
-        if self.0 != -1 {
-            unsafe { close(self.0) };
-        }
+        unsafe { close(self.0) };
     }
 }

--- a/src/utils/guard.rs
+++ b/src/utils/guard.rs
@@ -1,15 +1,13 @@
 use core::ptr::NonNull;
-use libc::closedir;
+use libc::{DIR, closedir};
 
-pub struct DirGuard(Option<NonNull<libc::DIR>>);
+pub struct DirGuard(Option<NonNull<DIR>>);
 
 impl DirGuard {
     /// 创建一个新的 `DirGuard`，包装一个 `DIR*` 指针。
-    pub fn new(dir: *mut libc::DIR) -> Option<Self> {
-        let ptr = NonNull::new(dir);
-        ptr.map(|p| Self(Some(p)))
+    pub const fn new(dir: *mut DIR) -> Self {
+        Self(NonNull::new(dir))
     }
-
     /// 关闭目录并释放资源。
     pub fn close(&mut self) {
         if let Some(dir) = self.0.take() {

--- a/src/utils/guard.rs
+++ b/src/utils/guard.rs
@@ -1,0 +1,25 @@
+use core::ptr::NonNull;
+use libc::closedir;
+
+pub struct DirGuard(Option<NonNull<libc::DIR>>);
+
+impl DirGuard {
+    /// 创建一个新的 `DirGuard`，包装一个 `DIR*` 指针。
+    pub fn new(dir: *mut libc::DIR) -> Option<Self> {
+        let ptr = NonNull::new(dir);
+        ptr.map(|p| Self(Some(p)))
+    }
+
+    /// 关闭目录并释放资源。
+    pub fn close(&mut self) {
+        if let Some(dir) = self.0.take() {
+            let _ = unsafe { closedir(dir.as_ptr()) };
+        }
+    }
+}
+
+impl Drop for DirGuard {
+    fn drop(&mut self) {
+        self.close();
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -1,3 +1,4 @@
 pub mod affinity_utils;
+pub mod guard;
 pub mod node_reader;
 pub mod sleep;

--- a/src/utils/node_reader.rs
+++ b/src/utils/node_reader.rs
@@ -1,13 +1,14 @@
 use anyhow::Result;
 use compact_str::CompactString;
 use std::{fs::File, io::Read, path::Path};
+use stringzilla::sz;
 
 pub fn read_file(file: &Path) -> Result<CompactString> {
     let mut file = File::open(file)?;
-    let mut buffer = [0u8; 128];
+    let mut buffer = [0u8; 32];
     let _ = file.read(&mut buffer)?;
-    let null_pos = buffer.iter().position(|&b| b == 0x00);
-    let buffer = null_pos.map_or(&buffer[..], |pos| &buffer[..pos]);
+    let pos = sz::find(buffer, b"\0");
+    let buffer = pos.map_or(&buffer[..], |pos| &buffer[..pos]);
     let buffer = CompactString::from_utf8(buffer)?;
     Ok(buffer)
 }

--- a/src/utils/node_reader.rs
+++ b/src/utils/node_reader.rs
@@ -1,7 +1,7 @@
 use super::guard::FileGuard;
 use anyhow::{Result, anyhow};
 use compact_str::CompactString;
-use libc::{O_RDONLY, c_void, open, read};
+use libc::{O_RDONLY, O_WRONLY, c_void, open, read, write};
 use likely_stable::unlikely;
 use stringzilla::sz;
 extern crate alloc;
@@ -31,4 +31,23 @@ pub fn read_to_byte<const N: usize>(file: &str) -> Result<[u8; N]> {
         }
     }
     Ok(buffer)
+}
+
+pub fn write_to_byte<const N: usize>(file: &str, msg: &str) -> Result<()> {
+    let c_file = CString::new(file)?;
+    let msg = CString::new(msg)?;
+    // let buffer = [0u8; N];
+    unsafe {
+        let fd = open(c_file.as_ptr(), O_WRONLY);
+        if unlikely(fd == -1) {
+            return Err(anyhow!("Cannot open file."));
+        }
+        let _fd_guard = FileGuard::new(fd);
+        let bytes_write = write(fd, msg.as_ptr().cast::<c_void>(), N);
+
+        if unlikely(bytes_write == -1) {
+            return Err(anyhow!("Cannot write file."));
+        }
+    }
+    Ok(())
 }

--- a/src/utils/node_reader.rs
+++ b/src/utils/node_reader.rs
@@ -8,16 +8,16 @@ extern crate alloc;
 use alloc::ffi::CString;
 
 pub fn read_file(file: &str) -> Result<CompactString> {
-    let buffer = read_to_byte(file)?;
+    let buffer = read_to_byte::<16>(file)?;
     let pos = sz::find(buffer, b"\n");
     let buffer = pos.map_or(&buffer[..], |pos| &buffer[..pos]);
     let buffer = CompactString::from_utf8(buffer)?;
     Ok(buffer)
 }
 
-pub fn read_to_byte(file: &str) -> Result<[u8; 16]> {
+pub fn read_to_byte<const N: usize>(file: &str) -> Result<[u8; N]> {
     let c_file = CString::new(file)?;
-    let mut buffer = [0u8; 16];
+    let mut buffer = [0u8; N];
     unsafe {
         let fd = open(c_file.as_ptr(), O_RDONLY);
         if unlikely(fd == -1) {
@@ -30,6 +30,5 @@ pub fn read_to_byte(file: &str) -> Result<[u8; 16]> {
             return Err(anyhow!("Cannot read file."));
         }
     }
-
     Ok(buffer)
 }

--- a/src/utils/node_reader.rs
+++ b/src/utils/node_reader.rs
@@ -36,7 +36,6 @@ pub fn read_to_byte<const N: usize>(file: &str) -> Result<[u8; N]> {
 pub fn write_to_byte<const N: usize>(file: &str, msg: &str) -> Result<()> {
     let c_file = CString::new(file)?;
     let msg = CString::new(msg)?;
-    // let buffer = [0u8; N];
     unsafe {
         let fd = open(c_file.as_ptr(), O_WRONLY);
         if unlikely(fd == -1) {

--- a/src/utils/node_reader.rs
+++ b/src/utils/node_reader.rs
@@ -3,15 +3,12 @@ use anyhow::{Result, anyhow};
 use compact_str::CompactString;
 use libc::{O_RDONLY, c_void, open, read};
 use likely_stable::unlikely;
-use std::{fs::File, io::Read};
 use stringzilla::sz;
 extern crate alloc;
 use alloc::ffi::CString;
 
 pub fn read_file(file: &str) -> Result<CompactString> {
-    let mut file = File::open(file)?;
-    let mut buffer = [0u8; 16];
-    let _ = file.read(&mut buffer)?;
+    let buffer = read_to_byte(file)?;
     let pos = sz::find(buffer, b"\n");
     let buffer = pos.map_or(&buffer[..], |pos| &buffer[..pos]);
     let buffer = CompactString::from_utf8(buffer)?;

--- a/src/utils/node_reader.rs
+++ b/src/utils/node_reader.rs
@@ -7,7 +7,7 @@ pub fn read_file(file: &Path) -> Result<CompactString> {
     let mut file = File::open(file)?;
     let mut buffer = [0u8; 32];
     let _ = file.read(&mut buffer)?;
-    let pos = sz::find(buffer, b"\0");
+    let pos = sz::find(buffer, b"\n");
     let buffer = pos.map_or(&buffer[..], |pos| &buffer[..pos]);
     let buffer = CompactString::from_utf8(buffer)?;
     Ok(buffer)

--- a/src/utils/node_reader.rs
+++ b/src/utils/node_reader.rs
@@ -7,7 +7,7 @@ pub fn read_file(file: &Path) -> Result<CompactString> {
     let mut file = File::open(file)?;
     let mut buffer = [0u8; 32];
     let _ = file.read(&mut buffer)?;
-    let pos = sz::find(buffer, b"\n");
+    let pos = sz::find(buffer, b"\0");
     let buffer = pos.map_or(&buffer[..], |pos| &buffer[..pos]);
     let buffer = CompactString::from_utf8(buffer)?;
     Ok(buffer)

--- a/src/utils/node_reader.rs
+++ b/src/utils/node_reader.rs
@@ -10,7 +10,7 @@ pub fn read_file(file: &str) -> Result<CompactString> {
     let _ = file.read(&mut buffer)?;
     let pos = sz::find(buffer, b"\n");
     let buffer = pos.map_or(&buffer[..], |pos| &buffer[..pos]);
-    let buffer = CompactString::from_utf8(buffer).unwrap();
+    let buffer = CompactString::from_utf8(buffer)?;
     Ok(buffer)
 }
 

--- a/src/utils/node_reader.rs
+++ b/src/utils/node_reader.rs
@@ -1,10 +1,12 @@
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use compact_str::CompactString;
+use likely_stable::unlikely;
 use std::{fs::File, io::Read};
 use stringzilla::sz;
+extern crate alloc;
+use alloc::ffi::CString;
 
 pub fn read_file(file: &str) -> Result<CompactString> {
-    // let mut file = File::open(file)?;
     let mut file = File::open(file)?;
     let mut buffer = [0u8; 32];
     let _ = file.read(&mut buffer)?;
@@ -15,8 +17,28 @@ pub fn read_file(file: &str) -> Result<CompactString> {
 }
 
 pub fn read_to_byte(file: &str) -> Result<[u8; 16]> {
-    let mut file = File::open(file)?;
+    #[cfg(debug_assertions)]
+    let start = minstant::Instant::now();
+    let c_file = CString::new(file)?;
+    let fd = unsafe { libc::open(c_file.as_ptr(), libc::O_RDONLY) };
+    if unlikely(fd == -1) {
+        return Err(anyhow!("Cannot open file."));
+    }
+
     let mut buffer = [0u8; 16];
-    let _ = file.read(&mut buffer)?;
+    let bytes_read =
+        unsafe { libc::read(fd, buffer.as_mut_ptr().cast::<libc::c_void>(), buffer.len()) };
+    unsafe {
+        libc::close(fd);
+    }
+
+    if unlikely(bytes_read == -1) {
+        return Err(anyhow!("Cannot read file."));
+    }
+    #[cfg(debug_assertions)]
+    {
+        let end = start.elapsed();
+        log::debug!("comm时间: {:?}", end);
+    }
     Ok(buffer)
 }

--- a/src/utils/node_reader.rs
+++ b/src/utils/node_reader.rs
@@ -1,5 +1,7 @@
+use super::guard::FileGuard;
 use anyhow::{Result, anyhow};
 use compact_str::CompactString;
+use libc::{O_RDONLY, c_void, open, read};
 use likely_stable::unlikely;
 use std::{fs::File, io::Read};
 use stringzilla::sz;
@@ -8,7 +10,7 @@ use alloc::ffi::CString;
 
 pub fn read_file(file: &str) -> Result<CompactString> {
     let mut file = File::open(file)?;
-    let mut buffer = [0u8; 32];
+    let mut buffer = [0u8; 16];
     let _ = file.read(&mut buffer)?;
     let pos = sz::find(buffer, b"\n");
     let buffer = pos.map_or(&buffer[..], |pos| &buffer[..pos]);
@@ -17,28 +19,21 @@ pub fn read_file(file: &str) -> Result<CompactString> {
 }
 
 pub fn read_to_byte(file: &str) -> Result<[u8; 16]> {
-    #[cfg(debug_assertions)]
-    let start = minstant::Instant::now();
     let c_file = CString::new(file)?;
-    let fd = unsafe { libc::open(c_file.as_ptr(), libc::O_RDONLY) };
-    if unlikely(fd == -1) {
-        return Err(anyhow!("Cannot open file."));
-    }
-
     let mut buffer = [0u8; 16];
-    let bytes_read =
-        unsafe { libc::read(fd, buffer.as_mut_ptr().cast::<libc::c_void>(), buffer.len()) };
     unsafe {
-        libc::close(fd);
+        let fd = open(c_file.as_ptr(), O_RDONLY);
+        let _fd_guard = FileGuard::new(fd);
+        if unlikely(fd == -1) {
+            return Err(anyhow!("Cannot open file."));
+        }
+
+        let bytes_read = read(fd, buffer.as_mut_ptr().cast::<c_void>(), 16);
+
+        if unlikely(bytes_read == -1) {
+            return Err(anyhow!("Cannot read file."));
+        }
     }
 
-    if unlikely(bytes_read == -1) {
-        return Err(anyhow!("Cannot read file."));
-    }
-    #[cfg(debug_assertions)]
-    {
-        let end = start.elapsed();
-        log::debug!("comm时间: {:?}", end);
-    }
     Ok(buffer)
 }

--- a/src/utils/node_reader.rs
+++ b/src/utils/node_reader.rs
@@ -1,15 +1,16 @@
 use anyhow::Result;
 use compact_str::CompactString;
-use std::{fs::File, io::Read, path::Path};
+use std::{fs::File, io::Read};
 use stringzilla::sz;
 
-pub fn read_file(file: &Path) -> Result<CompactString> {
+pub fn read_file(file: &str) -> Result<CompactString> {
+    // let mut file = File::open(file)?;
     let mut file = File::open(file)?;
     let mut buffer = [0u8; 32];
     let _ = file.read(&mut buffer)?;
     let pos = sz::find(buffer, b"\n");
     let buffer = pos.map_or(&buffer[..], |pos| &buffer[..pos]);
-    let buffer = CompactString::from_utf8(buffer)?;
+    let buffer = CompactString::from_utf8(buffer).unwrap();
     Ok(buffer)
 }
 

--- a/src/utils/node_reader.rs
+++ b/src/utils/node_reader.rs
@@ -24,7 +24,7 @@ pub fn read_to_byte<const N: usize>(file: &str) -> Result<[u8; N]> {
             return Err(anyhow!("Cannot open file."));
         }
         let _fd_guard = FileGuard::new(fd);
-        let bytes_read = read(fd, buffer.as_mut_ptr().cast::<c_void>(), 16);
+        let bytes_read = read(fd, buffer.as_mut_ptr().cast::<c_void>(), N);
 
         if unlikely(bytes_read == -1) {
             return Err(anyhow!("Cannot read file."));

--- a/src/utils/node_reader.rs
+++ b/src/utils/node_reader.rs
@@ -20,11 +20,10 @@ pub fn read_to_byte(file: &str) -> Result<[u8; 16]> {
     let mut buffer = [0u8; 16];
     unsafe {
         let fd = open(c_file.as_ptr(), O_RDONLY);
-        let _fd_guard = FileGuard::new(fd);
         if unlikely(fd == -1) {
             return Err(anyhow!("Cannot open file."));
         }
-
+        let _fd_guard = FileGuard::new(fd);
         let bytes_read = read(fd, buffer.as_mut_ptr().cast::<c_void>(), 16);
 
         if unlikely(bytes_read == -1) {

--- a/src/utils/sleep.rs
+++ b/src/utils/sleep.rs
@@ -1,6 +1,7 @@
-use core::time::Duration;
-use std::thread::sleep;
+use libc::sleep;
 
-pub fn sleep_millis(millis_second: u64) {
-    sleep(Duration::from_millis(millis_second));
+pub fn sleep_secs(millis_second: u32) {
+    unsafe {
+        sleep(millis_second);
+    }
 }


### PR DESCRIPTION
适配:
cod战区
金铲铲
时空猎人
拉力竞速3

性能优化:
使用libc库替代std的文件系统操作，同时对指针和文件描述符实现Drop特征，避免资源泄露(可通过ls -al /proc/$(pidof thread-opt)/fd 查看，你也可以用此方法对自己写的程序校验)
实现no_std，禁用一些库的不必要features
